### PR TITLE
Change datetime call and format for logging

### DIFF
--- a/macros/snow-mask/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply_masking_policy_list_for_models.sql
@@ -26,7 +26,7 @@
 
                 {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
                     {% if database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
-                        {{ log(modules.datetime.time() ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column, info=True) }}
+                        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column, info=True) }}
                         {% set query %}
                         alter {{materialization}}  {{database}}.{{schema}}.{{alias}} modify column  {{column}} set masking policy  {{database}}.{{schema}}.{{masking_policy_name}};
                         {% endset %}
@@ -58,7 +58,7 @@
                 {% set masking_policy_name  = meta_tuple[1] %}
 
                 {% if masking_policy_name is not none %}
-                    {{ log(modules.datetime.time() ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column, info=True) }}
+                    {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column, info=True) }}
                     {% set query %}
                         alter {{materialization}}  {{database}}.{{schema}}.{{alias}} modify column  {{column}} unset masking policy
                     {% endset %}

--- a/macros/snow-mask/apply_masking_policy_list_for_sources.sql
+++ b/macros/snow-mask/apply_masking_policy_list_for_sources.sql
@@ -25,7 +25,7 @@
 
                 {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
                     {% if database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
-                        {{ log(modules.datetime.time() ~ " | " ~ operation_type ~ "ing masking policy to source : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ name ~ '.' ~ column, info=True) }}
+                        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to source : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ name ~ '.' ~ column, info=True) }}
                         {% set query %}
                             {% if operation_type == "apply" %}
                                 alter {{materialization}}  {{database}}.{{schema}}.{{name}} modify column  {{column}} set masking policy  {{database}}.{{schema}}.{{masking_policy_name}}

--- a/macros/snow-mask/create_masking_policy.sql
+++ b/macros/snow-mask/create_masking_policy.sql
@@ -14,7 +14,7 @@
         {% set current_database = masking_policy[0] | string  %}
         {% set current_schema = masking_policy[1] | string  %}
         {% set current_policy_name = masking_policy[2] | string  %}
-        {{ log(modules.datetime.time() ~ " | creating masking policy           : " ~ current_database|upper ~ '.' ~ current_schema|upper ~ '.' ~ current_policy_name|upper , info=True) }}
+        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | creating masking policy           : " ~ current_database|upper ~ '.' ~ current_schema|upper ~ '.' ~ current_policy_name|upper , info=True) }}
         {% set call_masking_policy_macro = context["create_masking_policy_" | string ~ current_policy_name | string]  %}
         {{ run_query(call_masking_policy_macro(current_database, current_schema)) }}
     {% endfor %}

--- a/macros/snow-mask/get_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/get_masking_policy_list_for_models.sql
@@ -4,7 +4,7 @@
 
     {% for node in graph.nodes.values() -%}
 
-        {{ log(modules.datetime.time() ~ " | macro - now processing            : " ~ node.unique_id | string , info=False) }}
+        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | macro - now processing            : " ~ node.unique_id | string , info=False) }}
         
         {% set node_database = node.database | string %}
         {% set node_schema   = node.schema | string %}
@@ -14,7 +14,7 @@
         {% set meta_columns = dbt_snow_mask.get_meta_objects(node_unique_id,meta_key,node_resource_type) %}
     
         {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
-            {{ log(modules.datetime.time() ~ " | macro - meta_columns               : " ~ node_unique_id ~ " has " ~ meta_columns | string ~ " masking tags set", info=False) }}
+            {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | macro - meta_columns               : " ~ node_unique_id ~ " has " ~ meta_columns | string ~ " masking tags set", info=False) }}
 
             {% set column   = meta_tuple[0] %}
             {% set masking_policy_name  = meta_tuple[1] %}

--- a/macros/snow-mask/get_masking_policy_list_for_sources.sql
+++ b/macros/snow-mask/get_masking_policy_list_for_sources.sql
@@ -4,7 +4,7 @@
 
     {% for node in graph.sources.values() -%}
 
-        {{ log(modules.datetime.time() ~ " | macro - now processing            : " ~ node.unique_id | string , info=False) }}
+        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | macro - now processing            : " ~ node.unique_id | string , info=False) }}
         
         {% set node_database = node.database | string %}
         {% set node_schema   = node.schema | string %}
@@ -14,7 +14,7 @@
         {% set meta_columns = dbt_snow_mask.get_meta_objects(node_unique_id,meta_key,node_resource_type) %}
     
         {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
-            {{ log(modules.datetime.time() ~ " | macro - meta_columns               : " ~ node_unique_id ~ " has " ~ meta_columns | string ~ " masking tags set", info=False) }}
+            {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | macro - meta_columns               : " ~ node_unique_id ~ " has " ~ meta_columns | string ~ " masking tags set", info=False) }}
 
             {% set column   = meta_tuple[0] %}
             {% set masking_policy_name  = meta_tuple[1] %}


### PR DESCRIPTION
The current call to `modules.datetime.time()` is returning `00:00:00` instead of the current time.

```
00:00:00 | applying masking policy to model  :
```

This change updates the call to `modules.datetime.datetime.now().strftime("%H:%M:%S")` so the time of execution can be logged.

```
09:06:42 | applying masking policy to model  : 
```
