### PR TITLE
Update apply to work with source views and identifiers

### DIFF
--- a/macros/snow-mask/apply_masking_policy_list_for_sources.sql
+++ b/macros/snow-mask/apply_masking_policy_list_for_sources.sql
@@ -1,17 +1,24 @@
 {% macro apply_masking_policy_list_for_sources(meta_key,operation_type="apply") %}
 
     {% for node in graph.sources.values() -%}
-        
+
         {% set database = node.database | string %}
         {% set schema   = node.schema | string %}
         {% set name   = node.name | string %}
+        {% set identifier = (node.identifier | default(name, True)) | string %}
+
         {% set unique_id = node.unique_id | string %}
         {% set resource_type = node.resource_type | string %}
         {% set materialization = "table" %}
 
+        {% set relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
+        {% if relation.is_view %}
+          {% set materialization = "view" %}
+        {% endif %}
+
         {% set meta_columns = dbt_snow_mask.get_meta_objects(unique_id,meta_key,resource_type) %}
 
-        {% set masking_policy_list_sql %}     
+        {% set masking_policy_list_sql %}
             show masking policies in {{database}}.{{schema}};
             select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
         {% endset %}
@@ -19,18 +26,18 @@
         {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
             {% set column   = meta_tuple[0] %}
             {% set masking_policy_name  = meta_tuple[1] %}
-            
+
             {% if masking_policy_name is not none %}
                 {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
 
                 {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
                     {% if database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
-                        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to source : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ name ~ '.' ~ column, info=True) }}
+                        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to source : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ identifier ~ '.' ~ column, info=True) }}
                         {% set query %}
                             {% if operation_type == "apply" %}
-                                alter {{materialization}}  {{database}}.{{schema}}.{{name}} modify column  {{column}} set masking policy  {{database}}.{{schema}}.{{masking_policy_name}}
+                                alter {{materialization}}  {{database}}.{{schema}}.{{identifier}} modify column  {{column}} set masking policy  {{database}}.{{schema}}.{{masking_policy_name}}
                             {% elif operation_type == "unapply" %}
-                                alter {{materialization}}  {{database}}.{{schema}}.{{name}} modify column  {{column}} unset masking policy
+                                alter {{materialization}}  {{database}}.{{schema}}.{{identifier}} modify column  {{column}} unset masking policy
                             {% endif %}
                         {% endset %}
                         {% do run_query(query) %}
@@ -39,7 +46,7 @@
             {% endif %}
 
         {% endfor %}
-    
+
     {% endfor %}
-    
+
 {% endmacro %}


### PR DESCRIPTION
This change improves two sets of functionality, specifically, it will now apply masking where the source objects are views and where source objects have a dbt identifier defined. The change works for both apply and unapply operations.