### PR TITLE
Bump required dbt version to 1.0.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_snow_mask'
 version: '1.0.0'
 
-require-dbt-version: [">=0.18.0", "<=1.0.0"]
+require-dbt-version: [">=0.18.0", "<1.1.0"]
 config-version: 2
 
 target-path: "target"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_snow_mask'
 version: '1.0.0'
 
-require-dbt-version: [">=0.18.0", "<=0.22.0"]
+require-dbt-version: [">=0.18.0", "<=1.0.0"]
 config-version: 2
 
 target-path: "target"


### PR DESCRIPTION
I am pretty new to this package (and snowflake generally) but we are leveraging it and testing bumping our DBT up to v1.0.0. Everything seems to work as expected when running our `dbt run` and `run-operation create_masking_policy ...` with the `--no-version-check` argument added. 

Please let me know if there is any testing or anything else that would be helpful!