### PR TITLE
set result of run_query() to variable

### DIFF
--- a/macros/snow-mask/create_masking_policy.sql
+++ b/macros/snow-mask/create_masking_policy.sql
@@ -16,7 +16,7 @@
         {% set current_policy_name = masking_policy[2] | string  %}
         {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | creating masking policy           : " ~ current_database|upper ~ '.' ~ current_schema|upper ~ '.' ~ current_policy_name|upper , info=True) }}
         {% set call_masking_policy_macro = context["create_masking_policy_" | string ~ current_policy_name | string]  %}
-        {{ run_query(call_masking_policy_macro(current_database, current_schema)) }}
+        {% set result = run_query(call_masking_policy_macro(current_database, current_schema)) %}
     {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
Rationale for this change came from the fact that I wanted to automatically create masking policies on run start (without first running `dbt run-operation`). Sure there's a slight performance hit, but this would negate the need for `dbt run-operation` call as a one-off when new masking policy is created.

This change should have minimal impact so far as I can tell, but might not be the best solution to the problem. 

## Context

dbt's `on-run-(start|end)` hooks allow executing _SQL_ statements at the beginning of dbt's run. You can pass a macro to the hook, like so

```yaml
on-run-start: "{{ macro_name(parameter=value) }}"
```

## Problem
However dbt expects a text that it can then submit to the database. Current version of the package, utilises `run_query()` function, in a call to `create_masking_policy()` macro. The run_query() function is used to execute the `create masking policy` statement itself, however it also fetches the result of that statement in the same call. 

Without redirecting the result to a variable these results are then written out, and returned back to the caller, which in my case is the `on-run-start` hook. This in turn submits the _result_ of the `create masking policy` statement to the database, and it obviously fails. Below is an example of the run_query() call from `create_masking_policy` macro.

```
| column | data_type |
| ------ | --------- |
| status | Text      |
```

https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end

## Solution
My proposed solution is to redirect the output of the `run_query()` call to a variable, which would mean that the macro `create_masking_policy()` returns empty string, whilst also creating masking policies as requested.

Something tells me this is not the best solution -- I'm fairly new to dbt macros, happy to hear opinions on how to fix / implement this.