### PR TITLE
Enable functionality to use common schema in model database

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ vars:
 
 > ✅ If both `use_common_masking_policy_db` and `use_common_masking_policy_schema_only` are set to True, then `use_common_masking_policy_db` will supercede `use_common_masking_policy_schema_only`.
 
+**Allow Custom Materializations**
+
+To enable dbt_snow_mask to apply masking policies to models using custom materializations, configure the following parameter:
+* `custom_materializations_map` (optional): A dictionary containing key-value pairs mapping custom materializations (by name) to tables or views (reflecting the resulting object in Snowflake.) For each pair, the key must be the name of the custom_materialization and the value must be either `table` or `view` 
+
+**Example** : var block in dbt_project.yml to enable application of masking policies to a model generated using a custom materialiazition that ends up as a table in Snowflake.
+
+```yaml
+vars:
+  custom_materializations_map: '{ "custom_incremental": "table" }'
+```
+
 # How to apply masking policy ?
 
 - Masking is controlled by [meta](https://docs.getdbt.com/reference/resource-properties/meta) in [dbt resource properties](https://docs.getdbt.com/reference/declaring-properties) for sources and models. 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,16 @@ This dbt package contains macros that can be (re)used across dbt projects with s
 
 By default this process creates the masking policies in same directory as the database objects. You can change this default behavior by using following parameters in your `dbt_project.yml` 
 
+To change the database that your masking polices are created in set the following parameters:
 * `use_common_masking_policy_db` (optional): Flag to enable the usage of a common db/schema for all masking policies. Valid values are “True” OR "False"
 * `common_masking_policy_db` (optional): The database name for creating masking policies
 * `common_masking_policy_schema` (optional): The schema name for creating masking policies
+
+To change only the schema (so that a common schema is used for the masking policy in the same database that your model is being deployed to) set the following parameters:
+* `use_common_masking_policy_schema_only` (optional): Flag to enable the usage of a common schema in the current database for all masking policies. Valid values are “True” OR "False"
+* `common_masking_policy_schema` (optional): The schema name for creating masking policies
+
+If both `use_common_masking_policy_db` and `use_common_masking_policy_schema_only` are set to True, then `use_common_masking_policy_db` will supercede `use_common_masking_policy_schema_only`.
 
 **Example** : var block in dbt_project.yml
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ vars:
 
 **Allow Custom Materializations**
 
-To enable dbt_snow_mask to apply masking policies to models using custom materializations, configure the following parameter:
-* `custom_materializations_map` (optional): A dictionary containing key-value pairs mapping custom materializations (by name) to tables or views (reflecting the resulting object in Snowflake.) For each pair, the key must be the name of the custom_materialization and the value must be either `table` or `view` 
+To enable dbt_snow_mask to apply masking policies to models generated from custom materializations in dbt, configure the following parameter:
+* `custom_materializations_map` (optional): A dictionary containing key-value pairs mapping custom materializations in dbt to the objects they generate in Snowflake. For each pair, the key must be the name of the custom_materialization and the value must be either `table` or `view`. 
 
 **Example** : var block in dbt_project.yml to enable application of masking policies to a model generated using a custom materialiazition that ends up as a table in Snowflake.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ vars:
 
 **Method 2 : Use a common schema (in the current database)**
 
-To change only the schema (so that a common schema is used for the masking policy in the same database that your model is being deployed to) set the following parameters:
+To change only the schema (so that a common masking policy schema is used in the same database as your model) set the following parameters:
 * `use_common_masking_policy_schema_only` (optional): Flag to enable the usage of a common schema in the current database for all masking policies. Valid values are “True” OR "False"
 * `common_masking_policy_schema` (optional): The schema name for creating masking policies
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This dbt package contains macros that can be (re)used across dbt projects with s
 By default this process creates the masking policies in same directory as the database objects. There are 2 methods for changing the default behavior by using the following parameters in your `dbt_project.yml` 
 
 **Method 1 : Use a common database**
+
 To change the database that your masking polices are created in set the following parameters:
 * `use_common_masking_policy_db` (optional): Flag to enable the usage of a common db/schema for all masking policies. Valid values are “True” OR "False"
 * `common_masking_policy_db` (optional): The database name for creating masking policies
@@ -63,6 +64,7 @@ vars:
 ```
 
 **Method 2 : Use a common schema (in the current database)**
+
 To change only the schema (so that a common schema is used for the masking policy in the same database that your model is being deployed to) set the following parameters:
 * `use_common_masking_policy_schema_only` (optional): Flag to enable the usage of a common schema in the current database for all masking policies. Valid values are “True” OR "False"
 * `common_masking_policy_schema` (optional): The schema name for creating masking policies
@@ -75,7 +77,7 @@ vars:
   common_masking_policy_schema: "COMPLIANCE"
 ```
 
-**Note** If both `use_common_masking_policy_db` and `use_common_masking_policy_schema_only` are set to True, then `use_common_masking_policy_db` will supercede `use_common_masking_policy_schema_only`.
+> ✅ If both `use_common_masking_policy_db` and `use_common_masking_policy_schema_only` are set to True, then `use_common_masking_policy_db` will supercede `use_common_masking_policy_schema_only`.
 
 # How to apply masking policy ?
 

--- a/README.md
+++ b/README.md
@@ -46,27 +46,36 @@ This dbt package contains macros that can be (re)used across dbt projects with s
 
 # How to configure database and schema for the masking policy ?
 
-By default this process creates the masking policies in same directory as the database objects. You can change this default behavior by using following parameters in your `dbt_project.yml` 
+By default this process creates the masking policies in same directory as the database objects. There are 2 methods for changing the default behavior by using the following parameters in your `dbt_project.yml` 
 
+**Method 1 : Use a common database**
 To change the database that your masking polices are created in set the following parameters:
 * `use_common_masking_policy_db` (optional): Flag to enable the usage of a common db/schema for all masking policies. Valid values are “True” OR "False"
 * `common_masking_policy_db` (optional): The database name for creating masking policies
 * `common_masking_policy_schema` (optional): The schema name for creating masking policies
 
-To change only the schema (so that a common schema is used for the masking policy in the same database that your model is being deployed to) set the following parameters:
-* `use_common_masking_policy_schema_only` (optional): Flag to enable the usage of a common schema in the current database for all masking policies. Valid values are “True” OR "False"
-* `common_masking_policy_schema` (optional): The schema name for creating masking policies
-
-If both `use_common_masking_policy_db` and `use_common_masking_policy_schema_only` are set to True, then `use_common_masking_policy_db` will supercede `use_common_masking_policy_schema_only`.
-
-**Example** : var block in dbt_project.yml
-
+**Example** : var block in dbt_project.yml to enable using a common masking policy database
 ```yaml
 vars:
   use_common_masking_policy_db: "True"
   common_masking_policy_db: "DEMO_DB"
   common_masking_policy_schema: "COMPLIANCE"
 ```
+
+**Method 2 : Use a common schema (in the current database)**
+To change only the schema (so that a common schema is used for the masking policy in the same database that your model is being deployed to) set the following parameters:
+* `use_common_masking_policy_schema_only` (optional): Flag to enable the usage of a common schema in the current database for all masking policies. Valid values are “True” OR "False"
+* `common_masking_policy_schema` (optional): The schema name for creating masking policies
+
+**Example** : var block in dbt_project.yml to enable using a common masking policy schema (in the current database)
+
+```yaml
+vars:
+  use_common_masking_policy_schema_only: "True"
+  common_masking_policy_schema: "COMPLIANCE"
+```
+
+**Note** If both `use_common_masking_policy_db` and `use_common_masking_policy_schema_only` are set to True, then `use_common_masking_policy_db` will supercede `use_common_masking_policy_schema_only`.
 
 # How to apply masking policy ?
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -18,11 +18,11 @@ clean-targets:
 
 # vars:
 #   use_common_masking_policy_db: "True"
-#   common_masking_policy_db: "DATA_WAREHOUSE_PREPROD_DSE3422"
-#   common_masking_policy_schema: "SHARED"
+#   common_masking_policy_db: "DEMO_DB"
+#   common_masking_policy_schema: "COMPLIANCE"
 
 #   use_common_masking_policy_schema_only: "True"
-#   common_masking_policy_schema: "SHARED"
+#   common_masking_policy_schema: "COMPLIANCE"
 
 seeds:
   dbt_snow_mask_integration_tests:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,8 +1,8 @@
-name: "dbt_snow_mask_integration_tests"
-version: "1.0"
+name: 'dbt_snow_mask_integration_tests'
+version: '1.0'
 config-version: 2
 
-profile: "dbt-snow-utils-integration-tests"
+profile: 'dbt-snow-utils-integration-tests'
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]
@@ -12,14 +12,14 @@ macro-paths: ["macros"]
 
 target-path: "target"
 clean-targets:
-  - "target"
-  - "dbt_packages"
-  - "logs"
+    - "target"
+    - "dbt_packages"
+    - "logs"
 
-# vars:
-#   use_common_masking_policy_db: "True"
-#   common_masking_policy_db: "DEMO_DB"
-#   common_masking_policy_schema: "COMPLIANCE"
+#vars:
+#  use_common_masking_policy_db: "True"
+#  common_masking_policy_db: "DEMO_DB"
+#  common_masking_policy_schema: "COMPLIANCE"
 
 #   use_common_masking_policy_schema_only: "True"
 #   common_masking_policy_schema: "COMPLIANCE"
@@ -32,10 +32,10 @@ seeds:
 models:
   pre-hook:
     - "{{ dbt_snow_mask.create_masking_policy('models')}}"
-  post-hook:
+  post-hook: 
     - "{{ dbt_snow_mask.apply_masking_policy('models') }}"
-    # - "{{ dbt_snow_mask.unapply_masking_policy('models') }}"
-
+#    - "{{ dbt_snow_mask.unapply_masking_policy('models') }}"
+  
   dbt_snow_mask_integration_tests:
     staging:
       database: "DEMO_DB"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,8 +1,8 @@
-name: 'dbt_snow_mask_integration_tests'
-version: '1.0'
+name: "dbt_snow_mask_integration_tests"
+version: "1.0"
 config-version: 2
 
-profile: 'dbt-snow-utils-integration-tests'
+profile: "dbt-snow-utils-integration-tests"
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]
@@ -12,14 +12,17 @@ macro-paths: ["macros"]
 
 target-path: "target"
 clean-targets:
-    - "target"
-    - "dbt_packages"
-    - "logs"
+  - "target"
+  - "dbt_packages"
+  - "logs"
 
-#vars:
-#  use_common_masking_policy_db: "True"
-#  common_masking_policy_db: "DEMO_DB"
-#  common_masking_policy_schema: "COMPLIANCE"
+# vars:
+#   use_common_masking_policy_db: "True"
+#   common_masking_policy_db: "DATA_WAREHOUSE_PREPROD_DSE3422"
+#   common_masking_policy_schema: "SHARED"
+
+#   use_common_masking_policy_schema_only: "True"
+#   common_masking_policy_schema: "SHARED"
 
 seeds:
   dbt_snow_mask_integration_tests:
@@ -29,10 +32,10 @@ seeds:
 models:
   pre-hook:
     - "{{ dbt_snow_mask.create_masking_policy('models')}}"
-  post-hook: 
+  post-hook:
     - "{{ dbt_snow_mask.apply_masking_policy('models') }}"
-#    - "{{ dbt_snow_mask.unapply_masking_policy('models') }}"
-  
+    # - "{{ dbt_snow_mask.unapply_masking_policy('models') }}"
+
   dbt_snow_mask_integration_tests:
     staging:
       database: "DEMO_DB"

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
@@ -16,17 +16,17 @@
         {% set masking_policy_schema = model.schema %}
 		
         {# Override the database and schema name when use_common_masking_policy_db flag is set #}
-        {# Override the schema name (in the current_database) when use_common_masking_policy_schema flag is set #}
-        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) or (var('use_common_masking_policy_schema', 'False')|upper in ['TRUE','YES']) -%}
+        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+            {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+            {% endif %}
+        {% endif %}
+
+        {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+        {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
             {% if var('common_masking_policy_schema') %}
                 {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
-
-                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_schema', 'False')|upper in ['FALSE','NO']) -%}
-                    {% if var('common_masking_policy_db') %}
-                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
-                    {% endif %}
-                {% endif %}
-                
             {% endif %}
         {% endif %}
 

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
@@ -6,10 +6,14 @@
         {% set alias    = model.alias %}    
         {% set database = model.database %}
         {% set schema   = model.schema %}
-        {% set materialization = model.config.get("materialized") %}
-        {% if materialization == "incremental" %}
-            {% set materialization = "table" %}
+        {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
+
+        {# Append custom materializations to the list of standard materializations  #}
+        {% if (var('custom_materializations_map', None) != None ) %}
+            {% do materialization_map.update(fromjson(var('custom_materializations_map'))) %}
         {% endif %}
+
+        {% set materialization = materialization_map[model.config.get("materialized")] %}
         {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
 
         {% set masking_policy_db = model.database %}
@@ -63,10 +67,14 @@
             {% set schema   = node.schema | string %}
             {% set node_unique_id = node.unique_id | string %}
             {% set node_resource_type = node.resource_type | string %}
-            {% set materialization = node.config.materialized | string %}
-            {% if materialization == "incremental" %}
-                {% set materialization = "table" %}
+            {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
+
+            {# Append custom materializations to the list of standard materializations  #}
+            {% if (var('custom_materializations_map', None) != None ) %}
+                {% do materialization_map.update(fromjson(var('custom_materializations_map'))) %}
             {% endif %}
+
+            {% set materialization = materialization_map[model.config.get("materialized")] %}
             {% set alias    = node.alias %}
 
             {% set meta_columns = dbt_snow_mask.get_meta_objects(node_unique_id,meta_key,node_resource_type) %}

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
@@ -6,6 +6,8 @@
         {% set alias    = model.alias %}    
         {% set database = model.database %}
         {% set schema   = model.schema %}
+
+        {# This dictionary stores a mapping between materializations in dbt and the objects they will generate in Snowflake  #}
         {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
 
         {# Append custom materializations to the list of standard materializations  #}

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
@@ -9,9 +9,7 @@
         {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
 
         {# Append custom materializations to the list of standard materializations  #}
-        {% if (var('custom_materializations_map', None) != None ) %}
-            {% do materialization_map.update(fromjson(var('custom_materializations_map'))) %}
-        {% endif %}
+        {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
 
         {% set materialization = materialization_map[model.config.get("materialized")] %}
         {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
@@ -70,9 +68,7 @@
             {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
 
             {# Append custom materializations to the list of standard materializations  #}
-            {% if (var('custom_materializations_map', None) != None ) %}
-                {% do materialization_map.update(fromjson(var('custom_materializations_map'))) %}
-            {% endif %}
+            {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
 
             {% set materialization = materialization_map[model.config.get("materialized")] %}
             {% set alias    = node.alias %}

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_sources.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_sources.sql
@@ -23,11 +23,18 @@
         {% set masking_policy_db = node.database %}
         {% set masking_policy_schema = node.schema %}
 		
-        {# Override the database and schema name when use common_masking_policy_db flag is set #}
-        {%- if (var('use_common_masking_policy_db', 'False')|upper == 'TRUE') or (var('use_common_masking_policy_db', 'False')|upper == 'YES') -%}
-            {% if var('common_masking_policy_db') and var('common_masking_policy_schema') %}
-                {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+        {# Override the database and schema name when use_common_masking_policy_db flag is set #}
+        {# Override the schema name (in the current_database) when use_common_masking_policy_schema flag is set #}
+        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) or (var('use_common_masking_policy_schema', 'False')|upper in ['TRUE','YES']) -%}
+            {% if var('common_masking_policy_schema') %}
                 {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+
+                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_schema', 'False')|upper in ['FALSE','NO']) -%}
+                    {% if var('common_masking_policy_db') %}
+                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                    {% endif %}
+                {% endif %}
+                
             {% endif %}
         {% endif %}
 

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_sources.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_sources.sql
@@ -24,17 +24,17 @@
         {% set masking_policy_schema = node.schema %}
 		
         {# Override the database and schema name when use_common_masking_policy_db flag is set #}
-        {# Override the schema name (in the current_database) when use_common_masking_policy_schema flag is set #}
-        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) or (var('use_common_masking_policy_schema', 'False')|upper in ['TRUE','YES']) -%}
+        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+            {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+            {% endif %}
+        {% endif %}
+
+        {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+        {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
             {% if var('common_masking_policy_schema') %}
                 {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
-
-                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_schema', 'False')|upper in ['FALSE','NO']) -%}
-                    {% if var('common_masking_policy_db') %}
-                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
-                    {% endif %}
-                {% endif %}
-                
             {% endif %}
         {% endif %}
 

--- a/macros/snow-mask/create-policy/create_masking_policy.sql
+++ b/macros/snow-mask/create-policy/create_masking_policy.sql
@@ -15,11 +15,18 @@
         {% set current_database = masking_policy[0] | string  %}
         {% set current_schema = masking_policy[1] | string  %}
 
-        {# Override the database and schema name when use common_masking_policy_db flag is set #}
-        {%- if (var('use_common_masking_policy_db', 'False')|upper == 'TRUE') or (var('use_common_masking_policy_db', 'False')|upper == 'YES') -%}
-            {% if var('common_masking_policy_db') and var('common_masking_policy_schema') %}
-                {% set current_database = var('common_masking_policy_db') | string  %}
-                {% set current_schema = var('common_masking_policy_schema') | string  %}
+        {# Override the database and schema name when use_common_masking_policy_db flag is set #}
+        {# Override the schema name (in the current_database) when use_common_masking_policy_schema flag is set #}
+        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) or (var('use_common_masking_policy_schema', 'False')|upper in ['TRUE','YES']) -%}
+            {% if var('common_masking_policy_schema') %}
+                {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+
+                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_schema', 'False')|upper in ['FALSE','NO']) -%}
+                    {% if var('common_masking_policy_db') %}
+                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                    {% endif %}
+                {% endif %}
+                
             {% endif %}
         {% endif %}
 

--- a/macros/snow-mask/create-policy/create_masking_policy.sql
+++ b/macros/snow-mask/create-policy/create_masking_policy.sql
@@ -12,31 +12,30 @@
 
     {% for masking_policy in masking_policies | unique -%}
 
-        {% set current_database = masking_policy[0] | string  %}
-        {% set current_schema = masking_policy[1] | string  %}
+        {% set masking_policy_db = masking_policy[0] | string  %}
+        {% set masking_policy_schema = masking_policy[1] | string  %}
 
         {# Override the database and schema name when use_common_masking_policy_db flag is set #}
-        {# Override the schema name (in the current_database) when use_common_masking_policy_schema flag is set #}
-        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) or (var('use_common_masking_policy_schema', 'False')|upper in ['TRUE','YES']) -%}
+        {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+            {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+            {% endif %}
+        {% endif %}
+
+        {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+        {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
             {% if var('common_masking_policy_schema') %}
                 {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
-
-                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_schema', 'False')|upper in ['FALSE','NO']) -%}
-                    {% if var('common_masking_policy_db') %}
-                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
-                    {% endif %}
-                {% endif %}
-                
             {% endif %}
         {% endif %}
 
         {% set current_policy_name = masking_policy[2] | string  %}
-        {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | creating masking policy           : " ~ current_database|upper ~ '.' ~ current_schema|upper ~ '.' ~ current_policy_name|upper , info=True) }}
-
-        {% do adapter.create_schema(api.Relation.create(database=current_database, schema=current_schema)) %}
+ 
+        {% do adapter.create_schema(api.Relation.create(database=masking_policy_db, schema=masking_policy_schema)) %}
 
         {% set call_masking_policy_macro = context["create_masking_policy_" | string ~ current_policy_name | string]  %}
-        {% set result = run_query(call_masking_policy_macro(current_database, current_schema)) %}
+        {% set result = run_query(call_masking_policy_macro(masking_policy_db, masking_policy_schema)) %}
     {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
A new variable has been added use_common_masking_policy_schema_only which allows for a common schema within the model database to be specified for storing masking policies.

(Similar to existing functionality which uses use_common_masking_policy_db to set a common database and schema to store masking policies.)