### PR TITLE
added oneresource functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ vars:
   ```yaml
   models:
     post-hook: 
-      - "{{ dbt_snow_mask.unapply_masking_policy('sources',mysource) }}"
+      - "{{ dbt_snow_mask.unapply_masking_policy('sources','mysource') }}"
   ```
 
   ```yaml

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ vars:
     - "{{ dbt_snow_mask.create_masking_policy('sources')}}"
   ```
 
-- Apply the masking policy by running below commands  
+- Apply the masking policy to your project by running below commands  
 
 | Resource Type | Command                                                                        |
 | ------------- | ------------------------------------------------------------------------------ |
@@ -174,6 +174,30 @@ vars:
     post-hook: 
       - "{{ dbt_snow_mask.apply_masking_policy('models') }}"
   ```
+
+- Apply the masking policy to a single resources by running below commands  
+
+| Resource Type | Command                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| sources       | `dbt run-operation apply_masking_policy --args '{"resource_type": "sources","resource_name": "mysource" }'` |
+| models        | `dbt run-operation apply_masking_policy --args '{"resource_type": "models","resource_name": "mymodel" }'` |
+
+- Alternatively, you can also apply the masking policies by specifying below `post-hook` OR `on-run-end` to `dbt_project.yml`
+  
+  **Example** : dbt_project.yml
+
+  ```yaml
+  models:
+    mymodel:
+      +post-hook: "{{ dbt_snow_mask.apply_masking_policy('models','mymodel')}}" 
+  ```
+
+  ```yaml
+  sources:
+    mysource:
+      +post-hook: "{{ dbt_snow_mask.apply_masking_policy('sources','mysource')}}" 
+  ```
+  
 
 # How to remove masking policy ?
 
@@ -192,6 +216,29 @@ vars:
   models:
     post-hook: 
       - "{{ dbt_snow_mask.unapply_masking_policy('models') }}"
+  ```
+
+- Remove the masking policy applied by this package to a single resource by running below commands  
+
+| Resource Type | Command                                                                          |
+| ------------- | -------------------------------------------------------------------------------- |
+| sources       | `dbt run-operation unapply_masking_policy --args '{"resource_type": "sources","resource_name": "mysource"}'` |
+| models        | `dbt run-operation unapply_masking_policy --args '{"resource_type": "models","resource_name": "mymodel"}'`  |
+
+- Alternatively, you can also apply the unmasking policies per resource by specifying below `post-hook` OR `on-run-end` to `dbt_project.yml`
+  
+  **Example** : dbt_project.yml
+
+  ```yaml
+  models:
+    post-hook: 
+      - "{{ dbt_snow_mask.unapply_masking_policy('sources',mysource) }}"
+  ```
+
+  ```yaml
+  models:
+    post-hook: 
+      - "{{ dbt_snow_mask.unapply_masking_policy('models',mymodel) }}"
   ```
 
 # How to validate masking policy ?

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ vars:
   ```yaml
   models:
     post-hook: 
-      - "{{ dbt_snow_mask.unapply_masking_policy('models',mymodel) }}"
+      - "{{ dbt_snow_mask.unapply_masking_policy('models','mymodel') }}"
   ```
 
 # How to validate masking policy ?

--- a/macros/snow-mask/apply-policy/apply_masking_policy.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy.sql
@@ -1,13 +1,16 @@
-{% macro apply_masking_policy(resource_type="models",meta_key="masking_policy") %}
+{% macro apply_masking_policy(resource_type="models",resource_name="undefined",meta_key="masking_policy") %}
 
     {% if execute %}
 
-        {% if resource_type == "sources" %}
+        {% if resource_type == "sources" and  resource_name == "undefined" %}
             {{ dbt_snow_mask.apply_masking_policy_list_for_sources(meta_key) }}
-        {% elif resource_type == "models" %}
-            {{ dbt_snow_mask.apply_masking_policy_list_for_models(meta_key) }}
+        {% elif resource_type == "models" and resource_name == "undefined" %}
+            {{ dbt_snow_mask.apply_masking_policy_list_for_models(meta_key) }}           
+        {% elif resource_type == "sources" and resource_name != "undefined" %}
+            {{ dbt_snow_mask.apply_masking_policy_list_for_onesource(meta_key,resource_name) }}
+        {% elif resource_type == "models" and resource_name != "undefined" %}
+            {{ dbt_snow_mask.apply_masking_policy_list_for_onemodel(meta_key,resource_name) }}
         {% endif %}
-
     {% endif %}
 
 {% endmacro %}

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_onemodel.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_onemodel.sql
@@ -5,11 +5,11 @@
     {% if operation_type == "apply" %}
         {% for node in graph.nodes.values() %}
             {%- if resource_name in node.path  -%}            
-                {% set model_id = model.unique_id | string %}
-                {% set alias    = model.alias %}    
-                {% set database = model.database %}
-                {% set schema   = model.schema %}
-                {% set model_resource_type = model.resource_type | string %}
+                {% set model_id = node.unique_id | string %}
+                {% set alias    = node.alias %}    
+                {% set database = node.database %}
+                {% set schema   = node.schema %}
+                {% set model_resource_type = node.resource_type | string %}
 
                 {% if model_resource_type|lower in ["model"] %}
 
@@ -19,11 +19,11 @@
                     {# Append custom materializations to the list of standard materializations  #}
                     {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
 
-                    {% set materialization = materialization_map[model.config.get("materialized")] %}
+                    {% set materialization = materialization_map[node.config.get("materialized")] %}
                     {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
 
-                    {% set masking_policy_db = model.database %}
-                    {% set masking_policy_schema = model.schema %}
+                    {% set masking_policy_db = node.database %}
+                    {% set masking_policy_schema = node.schema %}
                     
                     {# Override the database and schema name when use_common_masking_policy_db flag is set #}
                     {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_onemodel.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_onemodel.sql
@@ -1,0 +1,117 @@
+{% macro apply_masking_policy_list_for_onemodel(meta_key,resource_name,operation_type="apply") %}
+
+{% if execute %}
+{%set resource_name =  '/'+ resource_name +'/' %}
+    {% if operation_type == "apply" %}
+        {% for node in graph.nodes.values() %}
+            {%- if resource_name in node.path  -%}            
+                {% set model_id = model.unique_id | string %}
+                {% set alias    = model.alias %}    
+                {% set database = model.database %}
+                {% set schema   = model.schema %}
+                {% set model_resource_type = model.resource_type | string %}
+
+                {% if model_resource_type|lower in ["model"] %}
+
+                    {# This dictionary stores a mapping between materializations in dbt and the objects they will generate in Snowflake  #}
+                    {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
+
+                    {# Append custom materializations to the list of standard materializations  #}
+                    {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
+
+                    {% set materialization = materialization_map[model.config.get("materialized")] %}
+                    {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
+
+                    {% set masking_policy_db = model.database %}
+                    {% set masking_policy_schema = model.schema %}
+                    
+                    {# Override the database and schema name when use_common_masking_policy_db flag is set #}
+                    {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+                        {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                            {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                            {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                        {% endif %}
+                    {% endif %}
+
+                    {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+                    {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
+                        {% if var('common_masking_policy_schema') %}
+                            {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                        {% endif %}
+                    {% endif %}
+
+                    {% set masking_policy_list_sql %}     
+                        show masking policies in {{masking_policy_db}}.{{masking_policy_schema}};
+                        select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
+                    {% endset %}
+
+                    {# If there are some masking policies to be applied in this model, we should show the masking policies in the schema #}
+                    {% if meta_columns | length > 0 %}
+                        {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
+                    {% endif %}
+
+                    {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
+                        {% set column   = meta_tuple[0] %}
+                        {% set masking_policy_name  = meta_tuple[1] %}
+                            {% if masking_policy_name is not none %}
+
+                            {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
+                                {% if masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
+                                    {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column, info=True) }}
+                                    {% set query %}
+                                    alter {{materialization}}  {{database}}.{{schema}}.{{alias}} modify column  {{column}} set masking policy {{masking_policy_db}}.{{masking_policy_schema}}.{{masking_policy_name}};
+                                    {% endset %}
+                                    {% do run_query(query) %}
+                                {% endif %}
+                            {% endfor %}
+
+                        {% endif %}
+                    {% endfor %}
+
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+    {% elif operation_type == "unapply" %}
+
+        {% for node in graph.nodes.values() -%}
+            {%- if resource_name in node.path  -%}  
+                {% set database = node.database | string %}
+                {% set schema   = node.schema | string %}
+                {% set node_unique_id = node.unique_id | string %}
+                {% set node_resource_type = node.resource_type | string %}
+                {% set materialization_map = {"table": "table", "view": "view", "incremental": "table"} %}
+
+                {% if node_resource_type|lower in ["model"] %}
+
+                    {# Append custom materializations to the list of standard materializations  #}
+                    {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
+
+                    {% set materialization = materialization_map[node.config.get("materialized")] %}
+                    {% set alias    = node.alias %}
+
+                    {% set meta_columns = dbt_snow_mask.get_meta_objects(node_unique_id,meta_key,node_resource_type) %}
+
+                    {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
+                        {% set column   = meta_tuple[0] %}
+                        {% set masking_policy_name  = meta_tuple[1] %}
+
+                        {% if masking_policy_name is not none %}
+                            {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ database|upper ~ '.' ~ schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column, info=True) }}
+                            {% set query %}
+                                alter {{materialization}}  {{database}}.{{schema}}.{{alias}} modify column  {{column}} unset masking policy
+                            {% endset %}
+                            {% do run_query(query) %}
+                        {% endif %}
+                    
+                    {% endfor %}
+
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+    {% endif %}
+
+{% endif %}
+
+{% endmacro %}

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_onesource.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_onesource.sql
@@ -1,0 +1,80 @@
+{% macro apply_masking_policy_list_for_onesource(meta_key,resource_name,operation_type="apply") %}
+
+{% if execute %}
+
+    {% for node in graph.sources.values() -%}
+        {%- if node.source_name == resource_name -%} 
+            {% set database = node.database | string %}
+            {% set schema   = node.schema | string %}
+            {% set name   = node.name | string %}
+            {% set identifier = (node.identifier | default(name, True)) | string %}
+
+            {% set unique_id = node.unique_id | string %}
+            {% set resource_type = node.resource_type | string %}
+            {% set materialization = "table" %}
+
+            {% set relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
+            {% if relation.is_view %}
+            {% set materialization = "view" %}
+            {% endif %}
+
+            {% set meta_columns = dbt_snow_mask.get_meta_objects(unique_id,meta_key,resource_type) %}
+
+            {# Use the database and schema for the source node: #}
+            {#     In the apple for models variant of this file it instead uses the model.database/schema metadata #}
+            {% set masking_policy_db = node.database %}
+            {% set masking_policy_schema = node.schema %}
+            
+            {# Override the database and schema name when use_common_masking_policy_db flag is set #}
+            {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+                {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                    {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                    {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                {% endif %}
+            {% endif %}
+
+            {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+            {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
+                {% if var('common_masking_policy_schema') %}
+                    {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                {% endif %}
+            {% endif %}
+
+            {% set masking_policy_list_sql %}
+                show masking policies in {{masking_policy_db}}.{{masking_policy_schema}};
+                select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
+            {% endset %}
+
+            {# If there are some masking policies to be applied in this model, we should show the masking policies in the schema #}
+            {% if meta_columns | length > 0 %}
+                {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
+            {% endif %}
+
+            {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
+                {% set column   = meta_tuple[0] %}
+                {% set masking_policy_name  = meta_tuple[1] %}
+
+                {% if masking_policy_name is not none %}
+
+                    {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
+                        {% if masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
+                            {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to source : " ~ masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ identifier ~ '.' ~ column, info=True) }}
+                            {% set query %}
+                                {% if operation_type == "apply" %}
+                                    alter {{materialization}}  {{database}}.{{schema}}.{{identifier}} modify column  {{column}} set masking policy  {{masking_policy_db}}.{{masking_policy_schema}}.{{masking_policy_name}}
+                                {% elif operation_type == "unapply" %}
+                                    alter {{materialization}}  {{database}}.{{schema}}.{{identifier}} modify column  {{column}} unset masking policy
+                                {% endif %}
+                            {% endset %}
+                            {% do run_query(query) %}
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+
+{% endif %}
+
+{% endmacro %}

--- a/macros/snow-mask/apply-policy/unapply_masking_policy.sql
+++ b/macros/snow-mask/apply-policy/unapply_masking_policy.sql
@@ -1,11 +1,15 @@
-{% macro unapply_masking_policy(resource_type="models",meta_key="masking_policy",operation_type="unapply") %}
+{% macro unapply_masking_policy(resource_type="models",resource_name="undefined",meta_key="masking_policy",operation_type="unapply") %}
 
     {% if execute %}
 
-        {% if resource_type == "sources" %}
+        {% if resource_type == "sources" and  resource_name == "undefined" %}
             {{ dbt_snow_mask.apply_masking_policy_list_for_sources(meta_key,operation_type) }}
-        {% elif resource_type == "models" %}
+        {% elif resource_type == "models" and resource_name == "undefined" %}
             {{ dbt_snow_mask.apply_masking_policy_list_for_models(meta_key,operation_type) }}
+        {% elif resource_type == "sources" and resource_name != "undefined" %}
+            {{ dbt_snow_mask.apply_masking_policy_list_for_onesource(meta_key,resource_name,operation_type) }}
+        {% elif resource_type == "models" and resource_name != "undefined" %}
+            {{ dbt_snow_mask.apply_masking_policy_list_for_onemodel(meta_key,resource_name,operation_type) }}            
         {% endif %}
 
     {% endif %}


### PR DESCRIPTION
To enable masking and unmasking of single models or sources, functionality has been added as an optional parameter [resource_name].
The changeset should be backwards compatible.

I found the commands for unmasking too broad, affecting more resources than needed when applying of unapplying them. 
I introduced this optional parameter, to quickly mask or unmask just 1 resource (sourcename from jamlfile) or nodename/foldername for model. 
The old way, all sources would be unmasked during the `post-hook` or `on-run-end`, leaving unnecisary data exposed.

