### PR TITLE
Macro to allow creation and altering of masking policies - Issue #6

### DIFF
--- a/integration_tests/macros/snow-mask-ddl/create_masking_policy_mp_mask_timestamp.sql
+++ b/integration_tests/macros/snow-mask-ddl/create_masking_policy_mp_mask_timestamp.sql
@@ -1,0 +1,21 @@
+{% macro create_masking_policy_mp_mask_timestamp(node_database, node_schema) %}
+  {% set yaml_metadata %}
+    masking_policy_name: mp_mask_timestamp
+    masking_policy_params: "val timestamp_ntz"
+    masking_policy_return: "timestamp_ntz"
+    masking_policy_body: |
+      case 
+        when current_role() in ('SYSADMIN') then val 
+        else '1900-01-01'::timestamp_ntz
+      end
+  {% endset %}
+
+  {% set metadata_dict = fromyaml(yaml_metadata) %}
+
+  {{ dbt_snow_mask.create_alter_masking_policy(node_database=node_database,
+                                               node_schema=node_schema, 
+                                               masking_policy_name=metadata_dict['masking_policy_name'], 
+                                               masking_policy_params=metadata_dict['masking_policy_params'], 
+                                               masking_policy_return=metadata_dict['masking_policy_return'],
+                                               masking_policy_body=metadata_dict['masking_policy_body']) }}
+{% endmacro %}

--- a/integration_tests/models/sources/sakila/src_sakila.yml
+++ b/integration_tests/models/sources/sakila/src_sakila.yml
@@ -8,3 +8,6 @@ sources:
           - name: first_name
             meta:
                 masking_policy: mp_encrypt_pii
+          - name: create_date
+            meta: 
+                masking_policy: mp_mask_timestamp

--- a/integration_tests/snapshots/pii/ods_customers.yml
+++ b/integration_tests/snapshots/pii/ods_customers.yml
@@ -6,3 +6,6 @@ snapshots:
       - name: email
         meta:
           masking_policy: mp_encrypt_pii
+      - name: create_date
+        meta:
+          masking_policy: mp_mask_timestamp

--- a/macros/snow-mask/create-policy/create_alter_masking_policy.sql
+++ b/macros/snow-mask/create-policy/create_alter_masking_policy.sql
@@ -1,0 +1,43 @@
+{% macro create_alter_masking_policy(node_database, 
+                                     node_schema, 
+                                     masking_policy_name, 
+                                     masking_policy_params, 
+                                     masking_policy_return, 
+                                     masking_policy_body, 
+                                     masking_policy_type="masking") %}
+
+  {%- set masking_policy_relation = node_database ~ "." ~ node_schema ~ "." ~ masking_policy_name -%}
+  {%- set upper_masking_policy_name = masking_policy_name | upper -%}
+
+  {%- if execute -%}
+    {%- set lookup_query -%}
+      show {{ masking_policy_type }} policies like '{{ upper_masking_policy_name }}' in schema {{ node_schema }}
+    {%- endset -%}
+    {%- set policy_list = run_query(lookup_query) -%}
+
+    {%- if policy_list.columns["name"].values() | count > 0 -%}
+      alter {{ masking_policy_type }}  policy {{ masking_policy_relation }} set body
+    {%- else -%}
+      create {{ masking_policy_type }} policy if not exists {{ masking_policy_relation }} as (
+        
+      {%- if masking_policy_params is not string and masking_policy_params is iterable -%}
+        {%- for parameter in masking_policy_params -%}
+          {{ parameter }}{{ ", " if not loop.last }}
+        {%- endfor -%}
+      {%- else -%}
+        {{ masking_policy_params }}
+      {%- endif -%}
+        ) returns {{ masking_policy_return }} 
+    {%- endif -%}
+
+    {{ "->\n" }}
+
+    {%- if masking_policy_body is not string and masking_policy_body is iterable -%}  
+      {%- for code_line in masking_policy_body -%}
+        {{ code_line }} {{ "\n" if not loop.last }}
+      {%- endfor -%}
+    {%- else -%}
+      {{ masking_policy_body }}
+    {%- endif -%}
+  {%- endif -%}
+{% endmacro %}


### PR DESCRIPTION
The macro `create_alter_masking_policy` has been added.  It checks to see if the masking policy exists.  If it does not, it creates the masking policy.  If the masking policy does exist, it performs the command 'ALTER MASKING POLICY ... SET BODY'.  This allows the body of a masking policy to be changed without having to remove the assignments of the masking policy to tables/views.

This pull request also introduces a different way for specifying the macro that defines the masking policy.  Rather than creating a macro that has the 'CREATE OR REPLACE MASKING POLICY ...' statement, you specify the parts of the masking policy definition in yaml metadata variables and then call the `create_alter_masking_policy` macro to do the work.

The new macro `create_masking_policy_mp_mask_timestamp` uses that method.
