### PR TITLE
add for loop thru nodes to apply_masking_policy_list_for_models.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ vars:
 | models        | `dbt run -- model <model-name>`                                                |
 | snapshots     | `dbt snapshot --select <snapshot-name> --target <target-name>`                 |
 
-- Alternatively, you can also apply the masking policies by specifying below `post-hook` OR `on-run-end` to `dbt_project.yml`
+- Alternatively, you can also apply the masking policies by specifying below `post-hook` to `dbt_project.yml`
   
   **Example** : dbt_project.yml
 
@@ -192,11 +192,16 @@ vars:
       - "{{ dbt_snow_mask.apply_masking_policy('snapshots') }}"
   ```
 
-- If you prefer to add this directly to a dbt model, see below command for an correct example
+- If you prefer to add this directly to a dbt model, see below command for a correct example
   
   ```yaml
   {{ config(post_hook = "{{ dbt_snow_mask.apply_masking_policy('models') }}") }}
   ```
+
+- Note:   ```"{{ dbt_snow_mask.apply_masking_policy('sources') }}"``` can be added to ```on-run-end```, but 
+```"{{ dbt_snow_mask.apply_masking_policy('models') }}"``` and 
+  ```"{{ dbt_snow_mask.apply_masking_policy('snapshots') }}"``` should either be included specifically as post-hooks to 
+  the models or snapshots sections of dbt_project.yml or added as a custom config to an individual model.
 
 # How to remove masking policy ?
 

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
@@ -3,75 +3,79 @@
 {% if execute %}
 
     {% if operation_type == "apply" %}
+
+        {% for model in graph.nodes.values() %}
     
-        {% set model_id = model.unique_id | string %}
-        {% set alias    = model.alias %}    
-        {% set database = model.database %}
-        {% set schema   = model.schema %}
-        {% set model_resource_type = model.resource_type | string %}
+            {% set model_id = model.unique_id | string %}
+            {% set alias    = model.alias %}
+            {% set database = model.database %}
+            {% set schema   = model.schema %}
+            {% set model_resource_type = model.resource_type | string %}
 
-        {% if model_resource_type|lower in ["model", "snapshot"] %}
+            {% if model_resource_type|lower in ["model", "snapshot"] %}
 
-            {# This dictionary stores a mapping between materializations in dbt and the objects they will generate in Snowflake  #}
-            {% set materialization_map = {"table": "table", "view": "view", "incremental": "table", "snapshot": "table"} %}
+                {# This dictionary stores a mapping between materializations in dbt and the objects they will generate in Snowflake  #}
+                {% set materialization_map = {"table": "table", "view": "view", "incremental": "table", "snapshot": "table"} %}
 
-            {# Append custom materializations to the list of standard materializations  #}
-            {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
+                {# Append custom materializations to the list of standard materializations  #}
+                {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
 
-            {% set materialization = materialization_map[model.config.get("materialized")] %}
-            {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
+                {% set materialization = materialization_map[model.config.get("materialized")] %}
+                {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
 
-            {% set masking_policy_db = model.database %}
-            {% set masking_policy_schema = model.schema %}
+                {% set masking_policy_db = model.database %}
+                {% set masking_policy_schema = model.schema %}
             
-            {# Override the database and schema name when use_common_masking_policy_db flag is set #}
-            {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
-                {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
-                    {% set masking_policy_db = var('common_masking_policy_db') | string  %}
-                    {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                {# Override the database and schema name when use_common_masking_policy_db flag is set #}
+                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+                    {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                        {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                    {% endif %}
                 {% endif %}
-            {% endif %}
 
-            {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
-            {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
-                {% if var('common_masking_policy_schema') %}
-                    {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+                {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
+                    {% if var('common_masking_policy_schema') %}
+                        {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                    {% endif %}
                 {% endif %}
-            {% endif %}
 
-            {% set masking_policy_list_sql %}     
-                show masking policies in {{masking_policy_db}}.{{masking_policy_schema}};
-                select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
-            {% endset %}
+                {% set masking_policy_list_sql %}
+                    show masking policies in {{masking_policy_db}}.{{masking_policy_schema}};
+                    select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
+                {% endset %}
 
-            {# If there are some masking policies to be applied in this model, we should show the masking policies in the schema #}
-            {% if meta_columns | length > 0 %}
-                {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
-            {% endif %}
+                {# If there are some masking policies to be applied in this model, we should show the masking policies in the schema #}
+                {% if meta_columns | length > 0 %}
+                    {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
+                {% endif %}
 
-            {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
-                {% set column               = meta_tuple[0] %}
-                {% set masking_policy_name  = meta_tuple[1] %}
-                {% set conditional_columns  = meta_tuple[2] %}
+                {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
+                    {% set column               = meta_tuple[0] %}
+                    {% set masking_policy_name  = meta_tuple[1] %}
+                    {% set conditional_columns  = meta_tuple[2] %}
                 
-                {% if masking_policy_name is not none %}
+                    {% if masking_policy_name is not none %}
 
-                    {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
-                        {% if masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
-                            {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column ~ ' [force = ' ~ var('use_force_applying_masking_policy','False') ~ ']', info=True) }}
-                            {% set query %}
-                            alter {{materialization}} {{database}}.{{schema}}.{{alias}}
-                            modify column {{column}}
-                            set masking policy {{masking_policy_db}}.{{masking_policy_schema}}.{{masking_policy_name}} {% if conditional_columns | length > 0 %}using ({{column}}, {{conditional_columns|join(', ')}}){% endif %} {% if var('use_force_applying_masking_policy','False')|upper in ['TRUE','YES'] %} force {% endif %};
-                            {% endset %}
-                            {% do run_query(query) %}
-                        {% endif %}
-                    {% endfor %}
+                        {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
+                            {% if masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
+                                {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column ~ ' [force = ' ~ var('use_force_applying_masking_policy','False') ~ ']', info=True) }}
+                                {% set query %}
+                                alter {{materialization}} {{database}}.{{schema}}.{{alias}}
+                                modify column {{column}}
+                                set masking policy {{masking_policy_db}}.{{masking_policy_schema}}.{{masking_policy_name}} {% if conditional_columns | length > 0 %}using ({{column}}, {{conditional_columns|join(', ')}}){% endif %} {% if var('use_force_applying_masking_policy','False')|upper in ['TRUE','YES'] %} force {% endif %};
+                                {% endset %}
+                                {% do run_query(query) %}
+                            {% endif %}
+                        {% endfor %}
 
-                {% endif %}
-            {% endfor %}
+                    {% endif %}
+                {% endfor %}
 
-        {% endif %}
+            {% endif %}
+
+        {% endfor %}
     
     {% elif operation_type == "unapply" %}
 

--- a/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
+++ b/macros/snow-mask/apply-policy/apply_masking_policy_list_for_models.sql
@@ -4,78 +4,74 @@
 
     {% if operation_type == "apply" %}
 
-        {% for model in graph.nodes.values() %}
-    
-            {% set model_id = model.unique_id | string %}
-            {% set alias    = model.alias %}
-            {% set database = model.database %}
-            {% set schema   = model.schema %}
-            {% set model_resource_type = model.resource_type | string %}
+        {% set model_id = model.unique_id | string %}
+        {% set alias    = model.alias %}
+        {% set database = model.database %}
+        {% set schema   = model.schema %}
+        {% set model_resource_type = model.resource_type | string %}
 
-            {% if model_resource_type|lower in ["model", "snapshot"] %}
+        {% if model_resource_type|lower in ["model", "snapshot"] %}
 
-                {# This dictionary stores a mapping between materializations in dbt and the objects they will generate in Snowflake  #}
-                {% set materialization_map = {"table": "table", "view": "view", "incremental": "table", "snapshot": "table"} %}
+            {# This dictionary stores a mapping between materializations in dbt and the objects they will generate in Snowflake  #}
+            {% set materialization_map = {"table": "table", "view": "view", "incremental": "table", "snapshot": "table"} %}
 
-                {# Append custom materializations to the list of standard materializations  #}
-                {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
+            {# Append custom materializations to the list of standard materializations  #}
+            {% do materialization_map.update(fromjson(var('custom_materializations_map', '{}'))) %}
 
-                {% set materialization = materialization_map[model.config.get("materialized")] %}
-                {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
+            {% set materialization = materialization_map[model.config.get("materialized")] %}
+            {% set meta_columns = dbt_snow_mask.get_meta_objects(model_id,meta_key) %}
 
-                {% set masking_policy_db = model.database %}
-                {% set masking_policy_schema = model.schema %}
-            
-                {# Override the database and schema name when use_common_masking_policy_db flag is set #}
-                {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
-                    {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
-                        {% set masking_policy_db = var('common_masking_policy_db') | string  %}
-                        {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
-                    {% endif %}
+            {% set masking_policy_db = model.database %}
+            {% set masking_policy_schema = model.schema %}
+
+            {# Override the database and schema name when use_common_masking_policy_db flag is set #}
+            {%- if (var('use_common_masking_policy_db', 'False')|upper in ['TRUE','YES']) -%}
+                {% if (var('common_masking_policy_db') and var('common_masking_policy_schema')) %}
+                    {% set masking_policy_db = var('common_masking_policy_db') | string  %}
+                    {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
                 {% endif %}
-
-                {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
-                {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
-                    {% if var('common_masking_policy_schema') %}
-                        {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
-                    {% endif %}
-                {% endif %}
-
-                {% set masking_policy_list_sql %}
-                    show masking policies in {{masking_policy_db}}.{{masking_policy_schema}};
-                    select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
-                {% endset %}
-
-                {# If there are some masking policies to be applied in this model, we should show the masking policies in the schema #}
-                {% if meta_columns | length > 0 %}
-                    {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
-                {% endif %}
-
-                {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
-                    {% set column               = meta_tuple[0] %}
-                    {% set masking_policy_name  = meta_tuple[1] %}
-                    {% set conditional_columns  = meta_tuple[2] %}
-                
-                    {% if masking_policy_name is not none %}
-
-                        {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
-                            {% if masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
-                                {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column ~ ' [force = ' ~ var('use_force_applying_masking_policy','False') ~ ']', info=True) }}
-                                {% set query %}
-                                alter {{materialization}} {{database}}.{{schema}}.{{alias}}
-                                modify column {{column}}
-                                set masking policy {{masking_policy_db}}.{{masking_policy_schema}}.{{masking_policy_name}} {% if conditional_columns | length > 0 %}using ({{column}}, {{conditional_columns|join(', ')}}){% endif %} {% if var('use_force_applying_masking_policy','False')|upper in ['TRUE','YES'] %} force {% endif %};
-                                {% endset %}
-                                {% do run_query(query) %}
-                            {% endif %}
-                        {% endfor %}
-
-                    {% endif %}
-                {% endfor %}
-
             {% endif %}
 
-        {% endfor %}
+            {# Override the schema name (in the masking_policy_db) when use_common_masking_policy_schema_only flag is set #}
+            {%- if (var('use_common_masking_policy_schema_only', 'False')|upper in ['TRUE','YES']) and (var('use_common_masking_policy_db', 'False')|upper in ['FALSE','NO']) -%}
+                {% if var('common_masking_policy_schema') %}
+                    {% set masking_policy_schema = var('common_masking_policy_schema') | string  %}
+                {% endif %}
+            {% endif %}
+
+            {% set masking_policy_list_sql %}
+                show masking policies in {{masking_policy_db}}.{{masking_policy_schema}};
+                select $3||'.'||$4||'.'||$2 as masking_policy from table(result_scan(last_query_id()));
+            {% endset %}
+
+            {# If there are some masking policies to be applied in this model, we should show the masking policies in the schema #}
+            {% if meta_columns | length > 0 %}
+                {% set masking_policy_list = dbt_utils.get_query_results_as_dict(masking_policy_list_sql) %}
+            {% endif %}
+
+            {%- for meta_tuple in meta_columns if meta_columns | length > 0 %}
+                {% set column               = meta_tuple[0] %}
+                {% set masking_policy_name  = meta_tuple[1] %}
+                {% set conditional_columns  = meta_tuple[2] %}
+
+                {% if masking_policy_name is not none %}
+
+                    {% for masking_policy_in_db in masking_policy_list['MASKING_POLICY'] %}
+                        {% if masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper == masking_policy_in_db %}
+                            {{ log(modules.datetime.datetime.now().strftime("%H:%M:%S") ~ " | " ~ operation_type ~ "ing masking policy to model  : " ~ masking_policy_db|upper ~ '.' ~ masking_policy_schema|upper ~ '.' ~ masking_policy_name|upper ~ " on " ~ database ~ '.' ~ schema ~ '.' ~ alias ~ '.' ~ column ~ ' [force = ' ~ var('use_force_applying_masking_policy','False') ~ ']', info=True) }}
+                            {% set query %}
+                            alter {{materialization}} {{database}}.{{schema}}.{{alias}}
+                            modify column {{column}}
+                            set masking policy {{masking_policy_db}}.{{masking_policy_schema}}.{{masking_policy_name}} {% if conditional_columns | length > 0 %}using ({{column}}, {{conditional_columns|join(', ')}}){% endif %} {% if var('use_force_applying_masking_policy','False')|upper in ['TRUE','YES'] %} force {% endif %};
+                            {% endset %}
+                            {% do run_query(query) %}
+                        {% endif %}
+                    {% endfor %}
+
+                {% endif %}
+            {% endfor %}
+
+        {% endif %}
     
     {% elif operation_type == "unapply" %}
 


### PR DESCRIPTION
Fix for [issue 66](https://github.com/entechlog/dbt-snow-mask/issues/66). As stated in the issue comment, all this does is add a for loop after line 5 of apply_masking_policy_list_for_models.sql to fix the issue. I also updated the indentation to align with the new for statement, which made this PR look unfortunately heinous. Please forgive me if there was a way to avoid that :/ 

Ran the integration tests provided and create, apply, and unapply were successful for sources, models, and snapshots:

- [x] Create policy for Source
- [x] Apply policy to Source
- [x] Unapply policy to Source
- [x] Create policy for Model
- [x] Apply policy to Model
- [x] Unapply policy to Model
- [x] Create policy for Snapshot
- [x] Apply policy to Snapshot
- [x] Unapply policy to Snapshot

Here is the dbt-project.yml used:
```
name: 'dbt_snow_mask_integration_tests'
version: '1.0'
config-version: 2

profile: 'dbt-snow-utils-integration-tests'

model-paths: ["models"]
analysis-paths: ["analyses"]
test-paths: ["tests"]
seed-paths: ["seeds"]
macro-paths: ["macros"]
snapshot-paths: ["snapshots"]

target-path: "target"
clean-targets:
    - "target"
    - "dbt_packages"
    - "logs"

#vars:
#  use_force_applying_masking_policy: "True"
#  use_common_masking_policy_db: "True"
#  common_masking_policy_db: "DEMO_DB"
#  common_masking_policy_schema: "COMPLIANCE"
#  create_masking_policy_schema: "False"

#   use_common_masking_policy_schema_only: "True"
#   common_masking_policy_schema: "COMPLIANCE"

seeds:
  dbt_snow_mask_integration_tests:
    +schema: seeds

models:
  pre-hook:
    - "{{ dbt_snow_mask.create_masking_policy('models')}}"
  post-hook: 
    - "{{ dbt_snow_mask.apply_masking_policy('models') }}"
    - "{{ dbt_snow_mask.unapply_masking_policy('models') }}"

snapshots:
  pre-hook:
    - "{{ dbt_snow_mask.create_masking_policy('snapshots')}}"
  post-hook:
    - "{{ dbt_snow_mask.apply_masking_policy('snapshots') }}"
    - "{{ dbt_snow_mask.unapply_masking_policy('snapshots') }}"
  
  dbt_snow_mask_integration_tests:
    pii:
      database: "DBT_SNOW_MASK_TEST"
      schema: TEST

on-run-start:
  - "{{ dbt_snow_mask.create_masking_policy('sources')}}"

on-run-end:
  - "{{ dbt_snow_mask.apply_masking_policy('sources')}}"
  - "{{ dbt_snow_mask.unapply_masking_policy('sources')}}"
```

Here is the console output for `dbt snapshot` :
```
(dbt-warehouse) <user> integration_tests % dbt snapshot
20:10:00  Running with dbt=1.5.2
20:10:00  Registered adapter: snowflake=1.5.2
20:10:00  Unable to do partial parsing because a project config has changed
20:10:02  Found 2 models, 0 tests, 1 snapshot, 0 analyses, 552 macros, 3 operations, 2 seed files, 1 source, 0 exposures, 0 metrics, 0 groups
20:10:02  
20:10:05  
20:10:05  Running 1 on-run-start hook
20:10:06  1 of 1 START hook: dbt_snow_mask_integration_tests.on-run-start.0 .............. [RUN]
20:10:06  1 of 1 OK hook: dbt_snow_mask_integration_tests.on-run-start.0 ................. [OK in 0.00s]
20:10:06  
20:10:06  Concurrency: 1 threads (target='dev')
20:10:06  
20:10:06  1 of 1 START snapshot pii.ods_customers ........................................ [RUN]
20:10:12  16:10:12 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email [force = False]
20:10:12  16:10:12 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name [force = False]
20:10:13  16:10:13 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email [force = False]
20:10:13  16:10:13 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address [force = False]
20:10:14  16:10:14 | applying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email [force = False]
20:10:14  16:10:14 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email
20:10:14  16:10:14 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name
20:10:14  16:10:14 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email
20:10:14  16:10:14 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address
20:10:14  16:10:14 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email
20:10:15  1 of 1 OK snapshotted pii.ods_customers ........................................ [success in 9.04s]
20:10:15  
20:10:15  Running 2 on-run-end hooks
20:10:16  16:10:16 | applying masking policy to source : DBT_SNOW_MASK_TEST.SEEDS.MP_CONDITIONAL_CUSTOMER_PII on DBT_SNOW_MASK_TEST.seeds.customer.first_name [force = False]
20:10:16  1 of 2 START hook: dbt_snow_mask_integration_tests.on-run-end.0 ................ [RUN]
20:10:16  1 of 2 OK hook: dbt_snow_mask_integration_tests.on-run-end.0 ................... [OK in 0.00s]
20:10:17  16:10:17 | unapplying masking policy to source : DBT_SNOW_MASK_TEST.SEEDS.MP_CONDITIONAL_CUSTOMER_PII on DBT_SNOW_MASK_TEST.seeds.customer.first_name [force = False]
20:10:17  2 of 2 START hook: dbt_snow_mask_integration_tests.on-run-end.1 ................ [RUN]
20:10:17  2 of 2 OK hook: dbt_snow_mask_integration_tests.on-run-end.1 ................... [OK in 0.00s]
20:10:17  
20:10:17  
20:10:17  Finished running 1 snapshot, 3 hooks in 0 hours 0 minutes and 15.35 seconds (15.35s).
20:10:17  
20:10:17  Completed successfully
20:10:17  
20:10:17  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

```

here is the console output for `dbt run`

```
(dbt-warehouse) <user> integration_tests % dbt run
20:11:55  Running with dbt=1.5.2
20:11:55  Registered adapter: snowflake=1.5.2
20:11:55  Found 2 models, 0 tests, 1 snapshot, 0 analyses, 552 macros, 3 operations, 2 seed files, 1 source, 0 exposures, 0 metrics, 0 groups
20:11:55  
20:11:59  
20:11:59  Running 1 on-run-start hook
20:11:59  1 of 1 START hook: dbt_snow_mask_integration_tests.on-run-start.0 .............. [RUN]
20:11:59  1 of 1 OK hook: dbt_snow_mask_integration_tests.on-run-start.0 ................. [OK in 0.00s]
20:11:59  
20:11:59  Concurrency: 1 threads (target='dev')
20:11:59  
20:11:59  1 of 2 START sql view model TEST.stg_contacts .................................. [RUN]
20:12:02  16:12:02 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email [force = False]
20:12:03  16:12:03 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name [force = False]
20:12:03  16:12:03 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email [force = False]
20:12:03  16:12:03 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address [force = False]
20:12:04  16:12:04 | applying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email [force = False]
20:12:04  16:12:04 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email
20:12:05  16:12:05 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name
20:12:05  16:12:05 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email
20:12:05  16:12:05 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address
20:12:05  16:12:05 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email
20:12:06  16:12:06 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email [force = False]
20:12:06  16:12:06 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name [force = False]
20:12:06  16:12:06 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email [force = False]
20:12:06  16:12:06 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address [force = False]
20:12:07  16:12:07 | applying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email [force = False]
20:12:08  1 of 2 OK created sql view model TEST.stg_contacts ............................. [SUCCESS 1 in 8.11s]
20:12:08  2 of 2 START sql view model TEST.stg_customer .................................. [RUN]
20:12:10  16:12:10 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email [force = False]
20:12:11  16:12:11 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name [force = False]
20:12:11  16:12:11 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email [force = False]
20:12:12  16:12:12 | applying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address [force = False]
20:12:12  16:12:12 | applying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email [force = False]
20:12:12  16:12:12 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.TEST.stg_customer.email
20:12:13  16:12:13 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_CONDITIONAL_CONTACTS_PII on DBT_SNOW_MASK_TEST.TEST.stg_contacts.first_name
20:12:13  16:12:13 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_EMAIL on DBT_SNOW_MASK_TEST.TEST.stg_contacts.email
20:12:13  16:12:13 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.TEST.MP_IP on DBT_SNOW_MASK_TEST.TEST.stg_contacts.ip_address
20:12:13  16:12:13 | unapplying masking policy to model  : DBT_SNOW_MASK_TEST.PII.MP_ENCRYPT_PII on DBT_SNOW_MASK_TEST.pii.ods_customers.email
20:12:13  2 of 2 OK created sql view model TEST.stg_customer ............................. [SUCCESS 1 in 5.54s]
20:12:13  
20:12:13  Running 2 on-run-end hooks
20:12:14  16:12:14 | applying masking policy to source : DBT_SNOW_MASK_TEST.SEEDS.MP_CONDITIONAL_CUSTOMER_PII on DBT_SNOW_MASK_TEST.seeds.customer.first_name [force = False]
20:12:14  1 of 2 START hook: dbt_snow_mask_integration_tests.on-run-end.0 ................ [RUN]
20:12:14  1 of 2 OK hook: dbt_snow_mask_integration_tests.on-run-end.0 ................... [OK in 0.00s]
20:12:15  16:12:15 | unapplying masking policy to source : DBT_SNOW_MASK_TEST.SEEDS.MP_CONDITIONAL_CUSTOMER_PII on DBT_SNOW_MASK_TEST.seeds.customer.first_name [force = False]
20:12:15  2 of 2 START hook: dbt_snow_mask_integration_tests.on-run-end.1 ................ [RUN]
20:12:15  2 of 2 OK hook: dbt_snow_mask_integration_tests.on-run-end.1 ................... [OK in 0.00s]
20:12:15  
20:12:15  
20:12:15  Finished running 2 view models, 3 hooks in 0 hours 0 minutes and 19.95 seconds (19.95s).
20:12:15  
20:12:15  Completed successfully
20:12:15  
20:12:15  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2

```
Notes:

- In the dbt run console output, the masking policies are applied, unapplied, and then applied again after stg_contacts is built because it has a custom config posthook.
- running `apply_masking_policy('models')` or `apply_masking_policy('snapshots')` yield the same result (same for create), but this seems to be how the code was already written, so no functionality has changed there.

Attached is a screenshot of the test db structure created using your integration material:
<img width="292" alt="dbt-snow-mask-test-db" src="https://github.com/entechlog/dbt-snow-mask/assets/86364517/e1004bd4-cc26-414b-879f-9574a25f2365">

Please let me know if further testing is needed or if I can answer any questions. Thanks!