### PR TITLE
Create packages.yml to explicitly add dbt_utils

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=0.8.0", "<2.0.0"]


### PR DESCRIPTION
Your readme says that dbt_utils is necessary, but you don't have a `packages.yml` specifying that. 

With a `packages.yml` file referencing a hub package, you can specify a range of supported dbt_utils versions, and dbt deps will automatically install the highest version that is compatible with all packages in a project. I've provided the oldest dbt utils version that is compatible with dbt v1.0 and up. 